### PR TITLE
fix bug with default appendTo

### DIFF
--- a/src/flatpickr-defaults.service.ts
+++ b/src/flatpickr-defaults.service.ts
@@ -202,7 +202,7 @@ export class FlatpickrDefaults implements FlatpickrDefaultsInterface {
   /**
    * Instead of `body`, appends the calendar to the specified node instead.
    */
-  appendTo: HTMLElement = null;
+  appendTo: HTMLElement = undefined;
 
   /**
    * Whether clicking on the input should open the picker.


### PR DESCRIPTION
fixes a bug thrown on this line in flatpickr.js:
var customAppend = self.config.appendTo !== undefined && self.config.appendTo.nodeType;