### PR TITLE
fix: parse date in same way as flatpickr does it

### DIFF
--- a/src/flatpickr.directive.ts
+++ b/src/flatpickr.directive.ts
@@ -414,18 +414,40 @@ export class FlatpickrDirective
     if (this.convertModelValue && typeof value === 'string') {
       switch (this.mode) {
         case 'multiple':
-          const dates: Date[] = value.split('; ').map(str => new Date(str));
+          const dates: Date[] = value
+            .split('; ')
+            .map(str =>
+              this.instance.parseDate(
+                str,
+                this.instance.config.dateFormat,
+                !this.instance.config.enableTime
+              )
+            );
           this.onChangeFn(dates);
           break;
 
         case 'range':
-          const [from, to] = value.split(' to ').map(str => new Date(str));
+          const [from, to] = value
+            .split(this.instance.l10n.rangeSeparator)
+            .map(str =>
+              this.instance.parseDate(
+                str,
+                this.instance.config.dateFormat,
+                !this.instance.config.enableTime
+              )
+            );
           this.onChangeFn({ from, to });
           break;
 
         case 'single':
         default:
-          this.onChangeFn(new Date(value));
+          this.onChangeFn(
+            this.instance.parseDate(
+              value,
+              this.instance.config.dateFormat,
+              !this.instance.config.enableTime
+            )
+          );
       }
     } else {
       this.onChangeFn(value);

--- a/src/flatpickr.directive.ts
+++ b/src/flatpickr.directive.ts
@@ -19,6 +19,7 @@ import {
 } from './flatpickr-defaults.service';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { FLATPICKR } from './flatpickr.token';
+import { Instance } from 'flatpickr';
 
 export interface FlatPickrOutputOptions {
   selectedDates: Date[];
@@ -263,8 +264,8 @@ export class FlatpickrDirective
     FlatPickrDayCreateOutputOptions
   > = new EventEmitter();
 
-  private instance: any;
-
+  private instance: Instance;
+  private isDisabled = false;
   private initialValue: any;
 
   onChangeFn: (value: any) => void = () => {}; // tslint:disable-line
@@ -275,7 +276,7 @@ export class FlatpickrDirective
     private elm: ElementRef,
     private defaults: FlatpickrDefaults,
     private renderer: Renderer2,
-    @Inject(FLATPICKR) private flatpickr
+    @Inject(FLATPICKR) private flatpickrFactory
   ) {}
 
   ngAfterViewInit(): void {
@@ -367,13 +368,14 @@ export class FlatpickrDirective
       }
     });
     options.time_24hr = options.time24hr;
-    this.instance = this.flatpickr(this.elm.nativeElement, options);
+    this.instance = this.flatpickrFactory(this.elm.nativeElement, options);
+    this.setDisabledState(this.isDisabled);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.instance) {
       Object.keys(changes).forEach(inputKey => {
-        this.instance.set(inputKey, (this as any)[inputKey]);
+        this.instance.set(inputKey as any, (this as any)[inputKey]);
       });
     }
   }
@@ -405,7 +407,14 @@ export class FlatpickrDirective
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.renderer.setProperty(this.elm.nativeElement, 'disabled', isDisabled);
+    this.isDisabled = isDisabled;
+    if (this.instance) {
+      if (this.isDisabled) {
+        this.renderer.setProperty(this.instance._input, 'disabled', 'disabled');
+      } else {
+        this.renderer.removeAttribute(this.instance._input, 'disabled');
+      }
+    }
   }
 
   @HostListener('input')

--- a/test/flatpickr.directive.spec.ts
+++ b/test/flatpickr.directive.spec.ts
@@ -557,22 +557,46 @@ describe('mwl-flatpickr directive', () => {
       );
     });
 
-    it('should disable the input', async () => {
+    it('should disable the input with `altInput` flag', async () => {
       const fixture: ComponentFixture<
         ReactiveFormsComponent
       > = TestBed.createComponent(ReactiveFormsComponent);
       fixture.componentInstance.convertModelValue = true;
       fixture.componentInstance.mode = 'single';
+      fixture.componentInstance.altInput = true;
       fixture.detectChanges();
       await fixture.whenStable();
-      const input: DebugElement = fixture.debugElement.query(By.css('input'));
-      expect(input.nativeElement.disabled).to.equal(false);
+      const input: HTMLInputElement = fixture.nativeElement.querySelectorAll(
+        'input'
+      )[1];
+      expect(input.disabled).to.equal(false);
       fixture.componentInstance.form.controls.date.disable();
       fixture.detectChanges();
-      expect(input.nativeElement.disabled).to.equal(true);
+      expect(input.disabled).to.equal(true);
       fixture.componentInstance.form.controls.date.enable();
       fixture.detectChanges();
-      expect(input.nativeElement.disabled).to.equal(false);
+      expect(input.disabled).to.equal(false);
+    });
+
+    it('should disable the input without `altInput` flag', async () => {
+      const fixture: ComponentFixture<
+        ReactiveFormsComponent
+      > = TestBed.createComponent(ReactiveFormsComponent);
+      fixture.componentInstance.convertModelValue = true;
+      fixture.componentInstance.mode = 'single';
+      fixture.componentInstance.altInput = false;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const input: HTMLInputElement = fixture.nativeElement.querySelectorAll(
+        'input'
+      )[0];
+      expect(input.disabled).to.equal(false);
+      fixture.componentInstance.form.controls.date.disable();
+      fixture.detectChanges();
+      expect(input.disabled).to.equal(true);
+      fixture.componentInstance.form.controls.date.enable();
+      fixture.detectChanges();
+      expect(input.disabled).to.equal(false);
     });
   });
 });

--- a/test/flatpickr.directive.spec.ts
+++ b/test/flatpickr.directive.spec.ts
@@ -48,6 +48,8 @@ function clickFlatpickerDate(target: HTMLElement | Element) {
       [mode]="mode"
       [locale]="'en'"
       [convertModelValue]="convertModelValue"
+      [enableTime]="enableTime"
+      [dateFormat]="dateFormat"
       (flatpickrReady)="events.next({name: 'ready', event: $event})"
       (flatpickrValueUpdate)="events.next({name: 'valueUpdate', event: $event})"
       (flatpickrChange)="events.next({name: 'input', event: $event})"
@@ -65,6 +67,8 @@ class NgModelComponent {
   events: Subject<any> = new Subject();
   convertModelValue: boolean;
   mode: string;
+  enableTime = false;
+  dateFormat = 'Y-m-d';
 }
 
 // tslint:disable-next-line
@@ -173,7 +177,7 @@ describe('mwl-flatpickr directive', () => {
     });
 
     describe('convertModelValue', () => {
-      it('should convert the value to a date when in single mode', () => {
+      it('should convert the value to a date without time when in single mode', () => {
         const fixture: ComponentFixture<
           NgModelComponent
         > = TestBed.createComponent(NgModelComponent);
@@ -181,30 +185,66 @@ describe('mwl-flatpickr directive', () => {
         fixture.componentInstance.mode = 'single';
         fixture.detectChanges();
         const input: DebugElement = fixture.debugElement.query(By.css('input'));
-        input.nativeElement.value = '2017-04-01';
+        input.nativeElement.value = '2017-04-01T15:15:15';
         input.triggerEventHandler('input', { target: input.nativeElement });
         expect(fixture.componentInstance.modelValue).to.deep.equal(
-          new Date('2017-04-01')
+          new Date('2017-04-01T00:00:00')
         );
       });
 
-      it('should convert the value to an array of date when in multiple mode', () => {
+      it('should convert the value to a date with time when in single mode with `enableTime` flag', () => {
+        const fixture: ComponentFixture<
+          NgModelComponent
+        > = TestBed.createComponent(NgModelComponent);
+        fixture.componentInstance.convertModelValue = true;
+        fixture.componentInstance.mode = 'single';
+        fixture.componentInstance.dateFormat = 'Y-m-dTH:i:s';
+        fixture.componentInstance.enableTime = true;
+        fixture.detectChanges();
+        const input: DebugElement = fixture.debugElement.query(By.css('input'));
+        input.nativeElement.value = '2017-04-01T15:15:15';
+        input.triggerEventHandler('input', { target: input.nativeElement });
+        expect(fixture.componentInstance.modelValue).to.deep.equal(
+          new Date('2017-04-01T15:15:15')
+        );
+      });
+
+      it('should convert the value to an array of dates without time when in multiple mode', () => {
         const fixture: ComponentFixture<
           NgModelComponent
         > = TestBed.createComponent(NgModelComponent);
         fixture.componentInstance.convertModelValue = true;
         fixture.componentInstance.mode = 'multiple';
         fixture.detectChanges();
+
         const input: DebugElement = fixture.debugElement.query(By.css('input'));
-        input.nativeElement.value = '2017-04-01; 2017-04-02';
+        input.nativeElement.value = '2017-04-01T15:15:15; 2017-04-02T15:15:15';
         input.triggerEventHandler('input', { target: input.nativeElement });
         expect(fixture.componentInstance.modelValue).to.deep.equal([
-          new Date('2017-04-01'),
-          new Date('2017-04-02')
+          new Date('2017-04-01T00:00:00'),
+          new Date('2017-04-02T00:00:00')
         ]);
       });
 
-      it('should convert the value to a from / to object when in range mode', () => {
+      it('should convert the value to an array of dates with time when in multiple mode with `enableTime` flag', () => {
+        const fixture: ComponentFixture<
+          NgModelComponent
+        > = TestBed.createComponent(NgModelComponent);
+        fixture.componentInstance.convertModelValue = true;
+        fixture.componentInstance.mode = 'multiple';
+        fixture.componentInstance.dateFormat = 'Y-m-dTH:i:s';
+        fixture.componentInstance.enableTime = true;
+        fixture.detectChanges();
+        const input: DebugElement = fixture.debugElement.query(By.css('input'));
+        input.nativeElement.value = '2017-04-01T15:15:15; 2017-04-02T15:15:15';
+        input.triggerEventHandler('input', { target: input.nativeElement });
+        expect(fixture.componentInstance.modelValue).to.deep.equal([
+          new Date('2017-04-01T15:15:15'),
+          new Date('2017-04-02T15:15:15')
+        ]);
+      });
+
+      it('should convert the value to a from / to object without time when in range mode', () => {
         const fixture: ComponentFixture<
           NgModelComponent
         > = TestBed.createComponent(NgModelComponent);
@@ -212,11 +252,31 @@ describe('mwl-flatpickr directive', () => {
         fixture.componentInstance.mode = 'range';
         fixture.detectChanges();
         const input: DebugElement = fixture.debugElement.query(By.css('input'));
-        input.nativeElement.value = '2017-04-01 to 2017-04-02';
+        input.nativeElement.value =
+          '2017-04-01 15:15:15 to 2017-04-02 15:15:15';
         input.triggerEventHandler('input', { target: input.nativeElement });
         expect(fixture.componentInstance.modelValue).to.deep.equal({
-          from: new Date('2017-04-01'),
-          to: new Date('2017-04-02')
+          from: new Date('2017-04-01T00:00:00'),
+          to: new Date('2017-04-02T00:00:00')
+        });
+      });
+
+      it('should convert the value to a from / to object with time when in range mode with `enableTime` flag', () => {
+        const fixture: ComponentFixture<
+          NgModelComponent
+        > = TestBed.createComponent(NgModelComponent);
+        fixture.componentInstance.convertModelValue = true;
+        fixture.componentInstance.mode = 'range';
+        fixture.componentInstance.dateFormat = 'Y-m-dTH:i:s';
+        fixture.componentInstance.enableTime = true;
+        fixture.detectChanges();
+        const input: DebugElement = fixture.debugElement.query(By.css('input'));
+        input.nativeElement.value =
+          '2017-04-01 15:15:15 to 2017-04-02 15:15:15';
+        input.triggerEventHandler('input', { target: input.nativeElement });
+        expect(fixture.componentInstance.modelValue).to.deep.equal({
+          from: new Date('2017-04-01T15:15:15'),
+          to: new Date('2017-04-02T15:15:15')
         });
       });
 
@@ -474,7 +534,7 @@ describe('mwl-flatpickr directive', () => {
       input.nativeElement.value = '2017-04-01';
       input.triggerEventHandler('input', { target: input.nativeElement });
       expect(fixture.componentInstance.form.value).to.deep.equal({
-        date: new Date('2017-04-01')
+        date: new Date('2017-04-01T00:00:00')
       });
     });
 


### PR DESCRIPTION
Now directive parses dates exactly same way as flatpickr does it.
Such behaviour fixes several bugs with custom date formats as well as broken multi date picker.
