### PR TITLE
Support for using a different 'now' time (e.g. display for a different timezone)

### DIFF
--- a/karma.conf.ts
+++ b/karma.conf.ts
@@ -12,7 +12,7 @@ export default (config: any) => {
     frameworks: ['mocha'],
 
     // list of files / patterns to load in the browser
-    files: ['test/entry.ts'],
+    files: ['test/entry.ts', './node_modules/flatpickr/dist/flatpickr.css'],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/src/flatpickr-defaults.service.ts
+++ b/src/flatpickr-defaults.service.ts
@@ -130,6 +130,11 @@ export interface FlatpickrDefaultsInterface {
   noCalendar?: boolean;
 
   /**
+   * Provide a date for 'today', which will be used instead of "new Date()"
+   */
+  now?: Date | string | number;
+
+  /**
    * Function that expects a date string and must return a Date object.
    */
   parseDate?: (str: string) => Date;
@@ -317,6 +322,11 @@ export class FlatpickrDefaults implements FlatpickrDefaultsInterface {
    * Hides the day selection in calendar. Use it along with `enableTime` to create a time picker.
    */
   noCalendar: boolean = false;
+
+  /**
+   * Default now to the current date
+   */
+  now: Date | string | number = new Date();
 
   /**
    * Function that expects a date string and must return a Date object.

--- a/src/flatpickr.directive.ts
+++ b/src/flatpickr.directive.ts
@@ -170,6 +170,11 @@ export class FlatpickrDirective
   @Input() noCalendar: boolean;
 
   /**
+   * Provide a date for 'today', which will be used instead of "new Date()"
+   */
+  @Input() now?: Date | string | number;
+
+  /**
    * Function that expects a date string and must return a Date object.
    */
   @Input() parseDate: (str: string) => Date;
@@ -322,6 +327,7 @@ export class FlatpickrDirective
       mode: this.mode,
       nextArrow: this.nextArrow,
       noCalendar: this.noCalendar,
+      now: this.now,
       parseDate: this.parseDate,
       prevArrow: this.prevArrow,
       shorthandCurrentMonth: this.shorthandCurrentMonth,


### PR DESCRIPTION
I've added support for specifying a different (optional) now time, so that the currently selected day tracks with that. This is useful for when you want the picker to behave as if the current day for selection purposes is not the current day localtime.

I've added a basic unit test for this as well. Note that I also added a helper function to wait for a DOM element to exist (with timeout), such that the test could wait for flatpickr to do it's rendering and verify that it selects the correct day for 'now' as configured.

There's also an extra commit in there to enable the flatpickr CSS for the tests, so that rendering is completed (useful for debugging unit tests). Feel free to squash this if you don't find it useful or had excluded it for some other reason I'm not aware of.

Cheers & thanks for the nice components you have shared!