### PR TITLE
In some cases this.instance is undefined when destroying...

### DIFF
--- a/src/flatpickr.directive.ts
+++ b/src/flatpickr.directive.ts
@@ -458,7 +458,7 @@ export class FlatpickrDirective
   }
 
   ngOnDestroy(): void {
-    this.instance.destroy();
+    this.instance?.destroy();
   }
 
   writeValue(value: any): void {

--- a/src/flatpickr.directive.ts
+++ b/src/flatpickr.directive.ts
@@ -458,7 +458,9 @@ export class FlatpickrDirective
   }
 
   ngOnDestroy(): void {
-    this.instance?.destroy();
+    if (this.instance) {
+		this.instance.destroy();
+	}
   }
 
   writeValue(value: any): void {


### PR DESCRIPTION
Hi,
I have successfully integrated your library to formly, but there was only one problem: on the first load an error was printed to the console about calling destroy function of undefined. After some debugging I have found out that the problem is in the ngOnDestroy function: sometimes this.instance is undefined when ngOnDestroy is called (it only happend when using from formly).
Therefore I have made a fork and called destroy with the ?. operator, and everything started to work well. Could you please integrate this small change to your library?
Thank you!
Kind regards,
Tamas 