### PR TITLE
Fixed a bug to get the "convertModelValue" from the defaults

### DIFF
--- a/src/flatpickr.directive.ts
+++ b/src/flatpickr.directive.ts
@@ -437,6 +437,10 @@ export class FlatpickrDirective
     });
     options.time_24hr = options.time24hr;
 
+    if (typeof this.convertModelValue === 'undefined') {
+      this.convertModelValue = this.defaults.convertModelValue;
+    }
+
     // workaround bug in flatpickr 4.6 where it doesn't copy the classes across
     // TODO - remove once fix in https://github.com/flatpickr/flatpickr/issues/1860 is released
     options.altInputClass =


### PR DESCRIPTION
If you set the convertModelValue in the USER_DEFAULTS in the forRoot method it is not getting used.
Tried to fix this issue.