### PR TITLE
feat: add ignoredFocusElements input

### DIFF
--- a/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
@@ -207,6 +207,11 @@ export interface FlatpickrDefaultsInterface {
    * How the month should be displayed in the header of the calendar.
    */
   monthSelectorType?: 'static' | 'dropdown';
+
+  /**
+   * Array of HTML elements that should not close the picker on click.
+   */
+  ignoredFocusElements?: HTMLElement[];
 }
 
 @Injectable()
@@ -416,4 +421,9 @@ export class FlatpickrDefaults implements FlatpickrDefaultsInterface {
    * How the month should be displayed in the header of the calendar.
    */
   monthSelectorType: 'static' | 'dropdown' = 'static';
+
+  /**
+   * Array of HTML elements that should not close the picker on click.
+   */
+  ignoredFocusElements: HTMLElement[] = [];
 }

--- a/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
@@ -266,6 +266,11 @@ export class FlatpickrDirective
   @Input() monthSelectorType: 'static' | 'dropdown';
 
   /**
+   * Array of HTML elements that should not close the picker on click.
+   */
+  @Input() ignoredFocusElements: HTMLElement[] = [];
+
+  /**
    * Gets triggered once the calendar is in a ready state
    */
   @Output()
@@ -281,7 +286,8 @@ export class FlatpickrDirective
    * Gets triggered when the input value is updated with a new date string.
    */
   @Output()
-  flatpickrValueUpdate: EventEmitter<FlatPickrOutputOptions> = new EventEmitter();
+  flatpickrValueUpdate: EventEmitter<FlatPickrOutputOptions> =
+    new EventEmitter();
 
   /**
    * Gets triggered when the calendar is opened.
@@ -299,19 +305,22 @@ export class FlatpickrDirective
    * Gets triggered when the month is changed, either by the user or programmatically.
    */
   @Output()
-  flatpickrMonthChange: EventEmitter<FlatPickrOutputOptions> = new EventEmitter();
+  flatpickrMonthChange: EventEmitter<FlatPickrOutputOptions> =
+    new EventEmitter();
 
   /**
    * Gets triggered when the year is changed, either by the user or programmatically.
    */
   @Output()
-  flatpickrYearChange: EventEmitter<FlatPickrOutputOptions> = new EventEmitter();
+  flatpickrYearChange: EventEmitter<FlatPickrOutputOptions> =
+    new EventEmitter();
 
   /**
    * Take full control of every date cell with this output
    */
   @Output()
-  flatpickrDayCreate: EventEmitter<FlatPickrDayCreateOutputOptions> = new EventEmitter();
+  flatpickrDayCreate: EventEmitter<FlatPickrDayCreateOutputOptions> =
+    new EventEmitter();
 
   /**
    * The flatpickr instance where you can call methods like toggle(), open(), close() etc
@@ -373,6 +382,7 @@ export class FlatpickrDirective
       wrap: this.wrap,
       plugins: this.plugins,
       locale: this.locale,
+      ignoredFocusElements: this.ignoredFocusElements,
       onChange: (selectedDates: Date[], dateString: string, instance: any) => {
         this.flatpickrChange.emit({ selectedDates, dateString, instance });
       },
@@ -430,6 +440,8 @@ export class FlatpickrDirective
         }
       }
     });
+
+    // @ts-ignore
     options.time_24hr = options.time24hr;
 
     // workaround bug in flatpickr 4.6 where it doesn't copy the classes across


### PR DESCRIPTION
Hi,

Flatpickr has an undocumented option called `ignoredFocusElements` that takes an array of HTML elements.
When the user clicks outside the picker to close it and clicks one of these elements the event is ignored.

I recently had to handle this behavior in an Angular app I worked on it and I had to manually pass this option via the
Flatpickr instance. I thought that having a dedicated input was more convenient.