### PR TITLE
feat: add minTime and maxTime inputs

### DIFF
--- a/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
@@ -336,6 +336,16 @@ export class FlatpickrDefaults implements FlatpickrDefaultsInterface {
   minDate: string | Date | undefined = undefined;
 
   /**
+   * The maximum time that a user can pick to (inclusive).
+   */
+  maxTime: string | undefined = undefined;
+
+  /**
+   * The minimum time that a user can start picking from (inclusive).
+   */
+  minTime: string | undefined = undefined;
+
+  /**
    * Adjusts the step for the minute input (incl. scrolling).
    */
   minuteIncrement: number = 5;

--- a/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
@@ -112,6 +112,16 @@ export interface FlatpickrDefaultsInterface {
   minDate?: string | Date;
 
   /**
+   * The maximum time that a user can pick to (inclusive).
+   */
+  maxTime?: string;
+
+  /**
+   * The minimum time that a user can start picking from (inclusive).
+   */
+  minTime?: string;
+
+  /**
    * Adjusts the step for the minute input (incl. scrolling).
    */
   minuteIncrement?: number;

--- a/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
@@ -375,6 +375,8 @@ export class FlatpickrDirective
       inline: this.inline,
       maxDate: this.maxDate,
       minDate: this.minDate,
+      maxTime: this.maxTime,
+      minTime: this.minTime,
       minuteIncrement: this.minuteIncrement,
       mode: this.mode,
       nextArrow: this.nextArrow,

--- a/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
@@ -175,6 +175,16 @@ export class FlatpickrDirective
   @Input() minDate: string | Date;
 
   /**
+   * The maximum time that a user can pick to (inclusive).
+   */
+  @Input() maxTime: string;
+
+  /**
+   * The minimum time that a user can start picking from (inclusive).
+   */
+  @Input() minTime: string;
+
+  /**
    * Adjusts the step for the minute input (incl. scrolling).
    */
   @Input() minuteIncrement: number;


### PR DESCRIPTION
This adds support for minTime and maxTime options as per the documentation .  see [here](https://flatpickr.js.org/examples/#time-picker) and [here](https://flatpickr.js.org/examples/#datetimepicker-with-limited-time-range)