### PR TITLE
feat: add allowInvalidPreload input

### DIFF
--- a/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr-defaults.service.ts
@@ -29,6 +29,11 @@ export interface FlatpickrDefaultsInterface {
   allowInput?: boolean;
 
   /**
+   * Allows the preloading of an invalid date. When disabled, the field will be cleared if the provided date is invalid
+   */
+  allowInvalidPreload?: boolean;
+
+  /**
    * Instead of `body`, appends the calendar to the specified node instead.
    */
   appendTo?: HTMLElement;
@@ -246,6 +251,11 @@ export class FlatpickrDefaults implements FlatpickrDefaultsInterface {
    * Allows the user to enter a date directly input the input field. By default, direct entry is disabled.
    */
   allowInput: boolean = false;
+
+  /**
+   * Allows the preloading of an invalid date. When disabled, the field will be cleared if the provided date is invalid
+   */
+  allowInvalidPreload: boolean = false;
 
   /**
    * Instead of `body`, appends the calendar to the specified node instead.

--- a/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
+++ b/projects/angularx-flatpickr/src/lib/flatpickr.directive.ts
@@ -87,6 +87,12 @@ export class FlatpickrDirective
    */
   @Input() allowInput: boolean;
 
+
+  /**
+   * Allows the preloading of an invalid date. When disabled, the field will be cleared if the provided date is invalid
+   */
+  @Input() allowInvalidPreload: boolean;
+
   /**
    * Instead of `body`, appends the calendar to the specified node instead.
    */
@@ -357,6 +363,7 @@ export class FlatpickrDirective
       altInput: this.altInput,
       altInputClass: this.altInputClass,
       allowInput: this.allowInput,
+      allowInvalidPreload: this.allowInvalidPreload,
       appendTo: this.appendTo,
       ariaDateFormat: this.ariaDateFormat,
       clickOpens: this.clickOpens,


### PR DESCRIPTION
Adds missing [allowInvalidPreload](https://flatpickr.js.org/options/) option.
This allows the user to provide an invalid date on load. 